### PR TITLE
fix builder for proto v3 about optional statement

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,7 @@ impl BuilderExt for tonic_build::Builder {
 }
 fn main() {
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src/pb")
         .compile(
             &["protos/hub.proto", "protos/health_check.proto"],


### PR DESCRIPTION
add statement to build.rs, to fix the build-script for proto v3 about 'optional' setting.
```
    tonic_build::configure()
        .protoc_arg("--experimental_allow_proto3_optional")    // new
        .out_dir("src/pb")
```